### PR TITLE
Upgrade markdown-it to 12.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "index.js"
   ],
   "dependencies": {
-    "markdown-it": "^10.0.0"
+    "markdown-it": "^12.3.2"
   },
   "devDependencies": {
     "markdown-it-container": "^2.0.0",


### PR DESCRIPTION
This dependency update addresses the following security vulnerability: https://github.com/advisories/GHSA-6vfc-qv3f-vr6c

The test run passed, and I didn’t see any regressions in my quick tests.
In particular, this has been the only vulnerability in a few of my projects 😄 

Let me know if there’s anything I can to do help move this along.

Closes #31.