### PR TITLE
Update to markdown-it @^14.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jstransformer-markdown-it",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "markdown-it support for JSTransformers.",
   "keywords": [
     "jstransformer",
@@ -10,11 +10,11 @@
     "index.js"
   ],
   "dependencies": {
-    "markdown-it": "^13.0.1"
+    "markdown-it": "^14.1.0"
   },
   "devDependencies": {
-    "markdown-it-container": "^3.0.0",
-    "markdown-it-mark": "^3.0.0",
+    "markdown-it-container": "^4.0.0",
+    "markdown-it-mark": "^4.0.0",
     "test-jstransformer": "^1.0.0"
   },
   "scripts": {


### PR DESCRIPTION
Fixes `The punycode module is deprecated` warning that occurs when markdown-it 13.x is used with modern versions of node (22+).